### PR TITLE
Correct README section: "Building and running the tests outside of jane street"

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Building and running the tests outside of jane street
 ----------------------------------------
 
 Code using this extension must be compiled and linked using the
-`ppx_inline_test.runtime-lib` library. The `ppx_inline_test` syntax
+`ppx_inline_test.runner.lib` library. The `ppx_inline_test` syntax
 extension will reject any test if it wasn't passed a `-inline-test-lib
 libname` flag.
 


### PR DESCRIPTION
I was having trouble getting the tests to run when compiling with `ppx_inline_test.runtime-lib`, as well as not compiling with anything `ppx_inline_test` specific at all.

After some investigation I got it to work by compiling with `ppx_inline_test.runner.lib`. I don't know if this is a bug, but ATM the readme seems misleading.

For the uninitiated/curious: I found the underlying change that affects builds >=v0.9.0 (no extra packages were required at 113.33.03) to be the new guard statement [here](https://github.com/janestreet/ppx_inline_test/blob/master/runtime-lib/runtime.ml#L224), which requires [this](https://github.com/janestreet/ppx_inline_test/blob/master/runner/lib/am_testing.c) to be linked. That is, compiling with `ppx_inline_test.runner.lib` makes the runner go into test mode.

I did my verification in https://github.com/rootmos/ppx_inline_test_issue using ocamlbuild.