### PR TITLE
Respect Dune's inline_tests variable

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,1 @@
-(lang dune 1.5)
+(lang dune 1.10)

--- a/src/dune
+++ b/src/dune
@@ -1,5 +1,8 @@
 (library (name ppx_inline_test) (public_name ppx_inline_test)
- (kind ppx_rewriter) (ppx_runtime_libraries ppx_inline_test.runtime-lib)
+ (kind
+  (ppx_rewriter
+   (cookies (inline_tests %{inline_tests}))))
+ (ppx_runtime_libraries ppx_inline_test.runtime-lib)
  (libraries base ppxlib ppx_inline_test_libname)
  (preprocess (pps ppxlib.metaquot))
  (inline_tests.backend (runner_libraries ppx_inline_test.runner.lib)

--- a/src/ppx_inline_test.ml
+++ b/src/ppx_inline_test.ml
@@ -40,6 +40,24 @@ let () =
           Location.raise_errorf ~loc:id.loc
             "invalid 'inline-test' cookie (%s), expected one of: drop, drop_with_deadcode"
             s)
+;;
+
+(* Same as above, but for the standard one passed by dune *)
+let () =
+  Driver.Cookies.add_simple_handler "inline_tests"
+    Ast_pattern.(estring __')
+    ~f:(function
+      | None -> ()
+      | Some id ->
+        match id.txt with
+        | "enabled" -> maybe_drop_mode := Keep
+        | "disabled" -> maybe_drop_mode := Drop
+        | "ignored" -> maybe_drop_mode := Drop_with_deadcode
+        | s ->
+          Location.raise_errorf ~loc:id.loc
+            "invalid 'inline_tests' cookie (%s), expected one of: enabled, disabled or ignored"
+            s)
+;;
 
 let maybe_drop loc code =
   match !maybe_drop_mode with


### PR DESCRIPTION
So that inline tests are not included in release mode.