### PR TITLE
Upgrade to ppxlib.0.14.0

### DIFF
--- a/ppx_inline_test.opam
+++ b/ppx_inline_test.opam
@@ -15,7 +15,7 @@ depends: [
   "base"     {>= "v0.14" & < "v0.15"}
   "time_now" {>= "v0.14" & < "v0.15"}
   "dune"     {>= "2.0.0"}
-  "ppxlib"   {>= "0.11.0"}
+  "ppxlib"   {>= "0.14.0"}
 ]
 synopsis: "Syntax extension for writing in-line tests in ocaml code"
 description: "

--- a/src/ppx_inline_test.ml
+++ b/src/ppx_inline_test.ml
@@ -178,7 +178,7 @@ let expand_test_module ~loc ~path:_ ~name:id ~tags m =
   validate_extension_point_exn ~name_of_ppx_rewriter ~loc ~tags;
   apply_to_descr "test_module" ~loc ~inner_loc:m.pmod_loc None id tags
     (pexp_fun ~loc Nolabel None (punit ~loc)
-       (pexp_letmodule ~loc (Located.mk ~loc "M")
+       (pexp_letmodule ~loc (Located.mk ~loc (Some "M"))
           m
           (eunit ~loc)))
 ;;


### PR DESCRIPTION
The next release of ppxlib will use the 4.10 AST internally. This PR makes ppx_inline_test compatible with this new version. Probably worth waiting for the new release before merging this!
