### PR TITLE
Stop using [Ppxlib.File_path].

### DIFF
--- a/src/ppx_inline_test.ml
+++ b/src/ppx_inline_test.ml
@@ -93,7 +93,7 @@ let rec short_desc_of_expr ~max_len e =
 ;;
 
 let descr ~(loc : Location.t) ?(inner_loc = loc) e_opt id_opt =
-  let filename = File_path.get_default_path loc in
+  let filename = loc.loc_start.pos_fname in
   let line = loc.loc_start.pos_lnum in
   let start_pos = loc.loc_start.pos_cnum - loc.loc_start.pos_bol in
   let end_pos = inner_loc.Location.loc_end.pos_cnum - loc.loc_start.pos_bol in


### PR DESCRIPTION
The tip of `Ppxlib` removes the File_path `submodule`. This patch fixes `ppx_inline_test` for that change.