### PR TITLE
Make time_now optional

### DIFF
--- a/ppx_inline_test.opam
+++ b/ppx_inline_test.opam
@@ -13,9 +13,10 @@ depends: [
   "ocaml" {>= "5.1.0"}
   "base"
   "sexplib0"
-  "time_now"
   "dune"     {>= "3.11.0"}
   "ppxlib"   {>= "0.33.0"}
+depopts:[
+  "time_now"
 ]
 available: arch != "arm32" & arch != "x86_32"
 synopsis: "Syntax extension for writing in-line tests in ocaml code"

--- a/runtime-lib/dune
+++ b/runtime-lib/dune
@@ -1,5 +1,8 @@
 (library
  (name ppx_inline_test_lib)
  (public_name ppx_inline_test.runtime-lib)
- (libraries base inline_test_config sexplib0 time_now)
+ (libraries base inline_test_config sexplib0
+ (select timestamp.ml from
+   (time_now -> timestamp.time_now.ml)
+   (         -> timestamp.sys.ml)))
  (preprocess no_preprocessing))

--- a/runtime-lib/ppx_inline_test_lib.ml
+++ b/runtime-lib/ppx_inline_test_lib.ml
@@ -416,13 +416,6 @@ let testing =
   else `Not_testing
 ;;
 
-(* This function returns an int63 representing the number of nanos since
-   some (fixed) baseline.  On unix, this baseline will be the unix epoch,
-   and in javascript, the baseline will be "program initialization time."
-   Regardless, it's always safe to subtract two values and use the diff,
-   which is all that ppx_inline_test_lib uses it for. *)
-let timestamp_ns () = Time_now.nanosecond_counter_for_timing ()
-
 let where_to_cut_backtrace =
   lazy
     (Base.String.Search_pattern.create
@@ -430,7 +423,7 @@ let where_to_cut_backtrace =
 ;;
 
 let time_without_resetting_random_seeds f =
-  let before_ns = timestamp_ns () in
+  let before = Timestamp.get () in
   let res =
     (* To avoid noise in backtraces, we do two things.
 
@@ -445,7 +438,7 @@ let time_without_resetting_random_seeds f =
     try Ok (f ()) with
     | exn -> Error (exn, Printexc.get_backtrace ())
   in
-  time_sec := Base.Int63.(timestamp_ns () - before_ns |> to_float) /. 1e9;
+  time_sec := Timestamp.seconds_since before;
   res
 ;;
 

--- a/runtime-lib/timestamp.mli
+++ b/runtime-lib/timestamp.mli
@@ -1,0 +1,4 @@
+type t
+
+val get : unit -> t
+val seconds_since : t -> float

--- a/runtime-lib/timestamp.sys.ml
+++ b/runtime-lib/timestamp.sys.ml
@@ -1,0 +1,4 @@
+type t = float
+
+let get () = Sys.time ()
+let seconds_since before = get () -. before

--- a/runtime-lib/timestamp.time_now.ml
+++ b/runtime-lib/timestamp.time_now.ml
@@ -1,0 +1,9 @@
+type t = Base.Intt63.t
+
+(* This function returns an int63 representing the number of nanos since
+   some (fixed) baseline.  On unix, this baseline will be the unix epoch,
+   and in javascript, the baseline will be "program initialization time."
+   Regardless, it's always safe to subtract two values and use the diff,
+   which is all that ppx_inline_test_lib uses it for. *)
+let get () = Time_now.nanosecond_counter_for_timing ()
+let seconds_since before = Base.Int63.(get () - before |> to_float) /. 1e9

--- a/runtime-lib/timestamp.time_now.ml
+++ b/runtime-lib/timestamp.time_now.ml
@@ -1,4 +1,4 @@
-type t = Base.Intt63.t
+type t = Base.Int63.t
 
 (* This function returns an int63 representing the number of nanos since
    some (fixed) baseline.  On unix, this baseline will be the unix epoch,


### PR DESCRIPTION
This PR is trying to reduce the dependency cone of ppx_expect/ppx_inline_tests. It turns out that the dependency on `time_now` is responsible (transitively) for many additional deps[1].

I propose to make `time_now` an optional dependency and fallback to `Sys.time` if `time_now` is not available/installed.

Note that time_now is used to log duration in seconds in `-verbose` mode.

[1]
- ppx_cold
- ppx_compare
- ppx_enumerate
- ppx_globalize
- ppx_hash
- ppx_sexp_conv
- jst-config
- jane-street-headers
- ppx_base
- ppx_optcomp
- ppxlib_jane